### PR TITLE
Date time col name

### DIFF
--- a/R/daily_stat.R
+++ b/R/daily_stat.R
@@ -24,7 +24,7 @@ initial_check <- function(data, dt, val, by) {
   check_class(val, data, "numeric")
   check_one(dt, val)
   
-  data <- dplyr::arrange(data, !!!rlang::syms(c(by, "date_time")))
+  data <- dplyr::arrange(data, !!!rlang::syms(c(by, dt)))
 
   # Make sure grouping vars are character (prevents warnings when merging)
   if(!is.null(by)) data <- dplyr::mutate_at(data, by, as.character)
@@ -32,9 +32,9 @@ initial_check <- function(data, dt, val, by) {
   # Confirm that data is hourly sequential with no gaps
   data <- dplyr::group_by(data, !!!rlang::syms(by))
   check_groups(data, dt)
-  data <- dplyr::mutate(data, diff = difftime(.data$date_time, 
-                                              dplyr::lag(.data$date_time), 
-                                              units = "hours"))
+  data <- dplyr::mutate(data, diff = difftime(!!!rlang::syms(dt), 
+                                      dplyr::lag(!!!rlang::syms(dt)), 
+                                      units = "hours"))
 
   # Fill out gaps with NA
   if(any(data$diff < 1, na.rm = TRUE)) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -171,5 +171,5 @@ NULL
 # Function to check which version of tidyr, as syntax for nest() changed in v1.0
 # https://tidyr.tidyverse.org/articles/in-packages.html
 tidyr_new_interface <- function() {
-  packageVersion("tidyr") > "0.8.99"
+  utils::packageVersion("tidyr") > "0.8.99"
 }

--- a/tests/testthat/test-1_utils.R
+++ b/tests/testthat/test-1_utils.R
@@ -44,7 +44,7 @@ test_that("check_class gets appropriate match", {
 
 test_that("initial_check catches hourly problems", {
   
-  d <- d[-c(100:110),]
+  d <- dplyr::slice(d, -c(100:110))
   expect_gt(nrow(initial_check(d, dt = "date_time", val = "value", by = c("ems_id", "site"))),
             nrow(d))
   

--- a/tests/testthat/test-5_pm_1_daily_average.R
+++ b/tests/testthat/test-5_pm_1_daily_average.R
@@ -19,6 +19,13 @@ test_that("Runs with silently", {
   saveRDS(r2, "pm_daily2.rds")
 })
 
+test_that("a different name for the date_time col can be used", {
+  res <- pm25_sample_data %>% 
+    dplyr::rename(DATE_TIME = date_time) %>% 
+    pm_annual_caaqs(dt = "DATE_TIME", by = c("ems_id", "site"))
+  expect_is(res, "caaqs")
+})
+
 ret1 <- readRDS("pm_daily1.rds")
 ret2 <- readRDS("pm_daily2.rds")
 


### PR DESCRIPTION
`pm_annual_caaqs` didn't seem to like values for `dt` that aren't `date_time`. This PR is meant to fix that and add a test. Here is the bug reproduced:

``` r
library(rcaaqs)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

pm_annual_caaqs(pm25_sample_data, by = c("ems_id", "site"))
#> Calculating PM 2.5 daily average
#> Calculating PM 2.5 annual average
#> Calculating PM 2.5 annual CAAQS metric
#> 
#> CAAQS results for PM2.5 annual 
#>   * Includes CAAQS ambient results only
#> --------------------------------------
#> 4 elements:
#>       * daily_avg ( 10901 rows x 8 columns )
#>       * yearly_avg ( 30 rows x 14 columns )
#>       * three_yr_rolling ( 30 rows x 21 columns )
#>       * caaqs ( 30 rows x 12 columns )
#> Access them with the get_ functions (see ?get_caaqs)

pm25_sample_data %>%
  rename(DATE_TIME = date_time) %>%
  pm_annual_caaqs(dt = "DATE_TIME", by = c("ems_id", "site"))
#> Calculating PM 2.5 daily average
#> Error: arrange() failed at implicit mutate() step. 
#> x Could not create a temporary column for `..3`.
#> i `..3` is `date_time`.
```
