### PR TITLE
rcaaqs:::quantile2 returns the maximum value in x when probs=1 and type="caaqs"

### DIFF
--- a/R/yearly_stat.R
+++ b/R/yearly_stat.R
@@ -350,7 +350,9 @@ quantile2 <- function(x, probs = 0.98, na.rm = FALSE, names = FALSE, type = "caa
     n <- length(x)
     i.d <- probs * n
     i <- floor(i.d)
-    ret <- x[n - i]
+    
+    ret <- ifelse(n == i, x[1], x[n - i])
+    
     if (names) names(ret) <- paste0(probs * 100, "%")
   } else {
     ret <- stats::quantile(x = x, probs = probs, na.rm = na.rm, names = names, type = type)

--- a/tests/testthat/test-3_quantile2.R
+++ b/tests/testthat/test-3_quantile2.R
@@ -29,6 +29,11 @@ test_that("percentiles are correct with type = 'caaqs'", {
   expect_true(all.equal(quantile2(1:366, probs = 0.98, type = "caaqs"), 359))
 })
 
+
+test_that("percentiles are correct with type = 'caaqs' and probs = 1", {
+  expect_true(all.equal(quantile2(1:25, probs = 1, type = "caaqs"), 25))
+})
+  
 test_that("has names", {
   expect_true(names(quantile2(1:10, probs = 0.98, names = TRUE, type = "caaqs")) == "98%")
 })


### PR DESCRIPTION
Tackles #62 but uses `ifelse` so that the fxn is still vectorized. 

Note, there are 1176 PASSING & 9 FAILING tests on `main`(and the failures are unrelated to this issue). This PR adds an additional test, and so there are 1177 PASSING and still the 9 FAILING. I'll open a new issue re: addressing the test failures.